### PR TITLE
Adding "Not answered" Flair to submissions that are not answered

### DIFF
--- a/ouijewpy.py
+++ b/ouijewpy.py
@@ -7,7 +7,9 @@ from toolz.curried import *
 
 SPACE = "רווח"
 DEBUG = False
+FLAIR_NO_ANSWER = "טרם נענה"
 HEB_GOODBYE = "להתראות"
+
 CHECK_HOT = 30  # Number of posts checked on each iteartion
 
 load_dotenv()
@@ -173,6 +175,9 @@ def process_post(submission):
             submission.mod.flair(text=text)
     except IndexError:
         print("no winner")
+        text = FLAIR_NO_ANSWER
+        if not DEBUG:
+            submission.mod.flair(text=text)
 
 
 def test_process_post():


### PR DESCRIPTION
This was kinda wierd because the only place where code is excecuted if there is no answer inside in the IndexError Exception Line 176 and there was only "no winner" printed to Standard output after the Exception is caught